### PR TITLE
setting default value to query filter if filter is not set.

### DIFF
--- a/lister.js
+++ b/lister.js
@@ -119,7 +119,7 @@
                             if(filter.type=='select') {
 
                                 if(filter.model!='__all')
-                                    query[filter.name] = filter.model;
+                                    query[filter.name] = typeof filter.default !== 'undefined' && typeof filter.model === 'undefined' ? filter.default : filter.model ;
 
                             } else if(filter.type=='date') {
 


### PR DESCRIPTION
Needed if you always need request param to be send to API endpoint, and if filter is not set, it returns 'undefined' which removes request param from request.

Currently in `data` function we can set list of request parameters for gets like:
`angular.merge({project_id: project.id, form_types: ''}, query)`
And if we have filter available for `form_types`, it will return `undefined` initially to the `query`. So after merge, request parameter `form_types` will be removed from request.

With this fix, `default` value will be applied to the filter if filter is not set.
